### PR TITLE
feat: trim unnecessary padding chars for faster training / generation

### DIFF
--- a/frame_semantic_transformer/constants.py
+++ b/frame_semantic_transformer/constants.py
@@ -1,3 +1,4 @@
 MODEL_MAX_LENGTH = 512
 OFFICIAL_RELEASES = ["base", "small"]  # TODO: small, large
 MODEL_REVISION = "v0.0.1"
+PADDING_LABEL_ID = -100

--- a/frame_semantic_transformer/data/TaskSampleDataset.py
+++ b/frame_semantic_transformer/data/TaskSampleDataset.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Optional, Sequence
 import torch
 from torch.utils.data import Dataset
 from transformers import T5Tokenizer
-from frame_semantic_transformer.constants import MODEL_MAX_LENGTH
+from frame_semantic_transformer.constants import MODEL_MAX_LENGTH, PADDING_LABEL_ID
 
 from frame_semantic_transformer.data.augmentations import (
     LowercaseAugmentation,
@@ -90,7 +90,7 @@ class TaskSampleDataset(Dataset[Any]):
             truncation=True,
         )
         labels = torch.tensor(output_encoding.input_ids)
-        labels[labels == self.tokenizer.pad_token_id] = -100
+        labels[labels == self.tokenizer.pad_token_id] = PADDING_LABEL_ID
 
         return (input_ids, attention_mask, labels)
 

--- a/frame_semantic_transformer/train.py
+++ b/frame_semantic_transformer/train.py
@@ -15,6 +15,7 @@ from pytorch_lightning.callbacks.base import Callback
 from frame_semantic_transformer.constants import MODEL_MAX_LENGTH
 
 from frame_semantic_transformer.data.TaskSampleDataset import TaskSampleDataset
+from frame_semantic_transformer.data.data_utils import trim_batch
 from frame_semantic_transformer.data.load_framenet_samples import (
     load_sesame_train_samples,
     load_sesame_test_samples,
@@ -115,10 +116,13 @@ class TrainingModelWrapper(pl.LightningModule):
         return self.model(*args, **kwargs)
 
     def _step(self, batch: Any) -> Any:
+        input_ids, attention_mask, labels = trim_batch(
+            batch["input_ids"], batch["attention_mask"], batch["labels"]
+        )
         return self(
-            input_ids=batch["input_ids"],
-            attention_mask=batch["attention_mask"],
-            labels=batch["labels"],
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            labels=labels,
         )
 
     def training_step(self, batch: Any, _batch_idx: int) -> Any:  # type: ignore


### PR DESCRIPTION
This PR trims the extra padding characters from batches during training to help speed-up training. This should mean the model won't need to always attempt to generate 512 tokens of outputs regardless of how long the real output should be, and instead just generate until the end of the content.