### PR TITLE
fix: fixing errors when no frames are found

### DIFF
--- a/frame_semantic_transformer/FrameSemanticTransformer.py
+++ b/frame_semantic_transformer/FrameSemanticTransformer.py
@@ -213,4 +213,13 @@ class FrameSemanticTransformer:
                         frame_element_tuples
                     )
         results_map = self._collate_results(results_acc)
-        return [results_map[parsed_sentences_map[sentence]] for sentence in sentences]
+        results = []
+        for sentence in sentences:
+            mapped_sentence = parsed_sentences_map[sentence]
+            if mapped_sentence in results_map:
+                results.append(results_map[mapped_sentence])
+            else:
+                results.append(
+                    DetectFramesResult(sentence, trigger_locations=[], frames=[])
+                )
+        return results

--- a/frame_semantic_transformer/data/LoaderDataCache.py
+++ b/frame_semantic_transformer/data/LoaderDataCache.py
@@ -29,20 +29,20 @@ class LoaderDataCache:
         """
         results: dict[str, Frame] = {}
         for frame in self.loader.load_frames():
-            results[frame.name] = frame
+            results[normalize_frame_name(frame.name)] = frame
         return results
 
     def get_frame(self, name: str) -> Frame:
         """
         Get a frame by name
         """
-        return self.get_frames_by_name()[name]
+        return self.get_frames_by_name()[normalize_frame_name(name)]
 
     def is_valid_frame(self, name: str) -> bool:
         """
         Check if a frame name is valid
         """
-        return name in self.get_frames_by_name()
+        return normalize_frame_name(name) in self.get_frames_by_name()
 
     @lru_cache(1)
     def get_lexical_unit_bigram_to_frame_lookup_map(self) -> dict[str, list[str]]:
@@ -88,3 +88,10 @@ class LoaderDataCache:
 
     def _normalize_lexical_unit_ngram(self, ngram: list[str]) -> str:
         return "_".join([self.loader.normalize_lexical_unit_text(tok) for tok in ngram])
+
+
+def normalize_frame_name(frame_name: str) -> str:
+    """
+    Normalize a frame name to be lowercase and without underscores
+    """
+    return frame_name.lower().replace("_", "")

--- a/frame_semantic_transformer/data/tasks/FrameClassificationTask.py
+++ b/frame_semantic_transformer/data/tasks/FrameClassificationTask.py
@@ -32,7 +32,8 @@ class FrameClassificationTask(Task):
     ) -> str | None:
         for pred in prediction_outputs:
             if loader_cache.is_valid_frame(pred):
-                return pred
+                # fix any capitalization differences between pred and the frame name
+                return loader_cache.get_frame(pred).name
         return None
 
     # -- helper properties --

--- a/tests/test_frame_semantic_transformer.py
+++ b/tests/test_frame_semantic_transformer.py
@@ -3,13 +3,29 @@ from syrupy.assertion import SnapshotAssertion
 from frame_semantic_transformer import FrameSemanticTransformer
 
 
+transformer = FrameSemanticTransformer("small")
+
+
 def test_basic_detect_frames_functionality(snapshot: SnapshotAssertion) -> None:
-    transformer = FrameSemanticTransformer("small")
     result = transformer.detect_frames(
         "I'm getting quite hungry, but I can wait a bit longer."
     )
     assert result.sentence == "I'm getting quite hungry, but I can wait a bit longer."
     assert result == snapshot
+
+
+def test_problematic_sentence() -> None:
+    result = transformer.detect_frames("two cars parked on the sidewalk on the street")
+    assert result.sentence == "two cars parked on the sidewalk on the street"
+    assert len(result.trigger_locations) > 0
+    assert len(result.frames) > 0
+
+
+def test_no_results() -> None:
+    result = transformer.detect_frames("nope")
+    assert result.sentence == "nope"
+    assert len(result.trigger_locations) == 0
+    assert len(result.frames) == 0
 
 
 def test_basic_detect_frames_bulk() -> None:
@@ -18,7 +34,6 @@ def test_basic_detect_frames_bulk() -> None:
         "The chef gave the food to the customer.",
         "The hallway smelt of boiled cabbage and old rag mats.",
     ]
-    transformer = FrameSemanticTransformer("small")
     results = transformer.detect_frames_bulk(sentences)
     assert len(results) == 3
     for result, sentence in zip(results, sentences):


### PR DESCRIPTION
This PR fixes a bug likely introduced in #11, where if a sentence has no results a keyerror is thrown. In addition, this PR makes the frame detect handling more robust so if the model doesn't get the capitalization 100% correct on the identified frame this will still register the frame match rather than returning `None`. 

fixes #12