### PR TITLE
Align trigger-marked sentence to original sentence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv*
 env/
 venv/
 ENV/

--- a/frame_semantic_transformer/FrameSemanticTransformer.py
+++ b/frame_semantic_transformer/FrameSemanticTransformer.py
@@ -179,8 +179,12 @@ class FrameSemanticTransformer:
             ):
                 if isinstance(task, TriggerIdentificationTask):
                     # first identify triggers
-                    text_with_triggers_marked = task.parse_output(preds, self.loader_cache)
-                    trigger_locs = marked_string_to_locs(task.text, text_with_triggers_marked)
+                    text_with_triggers_marked = task.parse_output(
+                        preds, self.loader_cache
+                    )
+                    trigger_locs = marked_string_to_locs(
+                        task.text, text_with_triggers_marked
+                    )
                     for trigger_loc in trigger_locs:
                         tasks_queue.append(
                             FrameClassificationTask(

--- a/frame_semantic_transformer/FrameSemanticTransformer.py
+++ b/frame_semantic_transformer/FrameSemanticTransformer.py
@@ -168,9 +168,6 @@ class FrameSemanticTransformer:
         tasks_queue: list[Task] = []
         # slowly build up results from each task as they complete
         results_acc: ResultsAccumulator = defaultdict(dict)
-        # T5 doesn't necessarily have to output the original sentence, even though it's supposed to
-        # This map just keeps track of the original sentence for each output sentence so we can match them up
-        parsed_sentences_map: dict[str, str] = {}
         for sentence in sentences:
             tasks_queue.append(TriggerIdentificationTask(text=sentence))
         while len(tasks_queue) > 0:
@@ -182,9 +179,8 @@ class FrameSemanticTransformer:
             ):
                 if isinstance(task, TriggerIdentificationTask):
                     # first identify triggers
-                    result = task.parse_output(preds, self.loader_cache)
-                    parsed_sent, trigger_locs = marked_string_to_locs(result)
-                    parsed_sentences_map[task.text] = parsed_sent
+                    text_with_triggers_marked = task.parse_output(preds, self.loader_cache)
+                    trigger_locs = marked_string_to_locs(task.text, text_with_triggers_marked)
                     for trigger_loc in trigger_locs:
                         tasks_queue.append(
                             FrameClassificationTask(
@@ -215,9 +211,8 @@ class FrameSemanticTransformer:
         results_map = self._collate_results(results_acc)
         results = []
         for sentence in sentences:
-            mapped_sentence = parsed_sentences_map[sentence]
-            if mapped_sentence in results_map:
-                results.append(results_map[mapped_sentence])
+            if sentence in results_map:
+                results.append(results_map[sentence])
             else:
                 results.append(
                     DetectFramesResult(sentence, trigger_locations=[], frames=[])

--- a/frame_semantic_transformer/data/data_utils.py
+++ b/frame_semantic_transformer/data/data_utils.py
@@ -44,39 +44,41 @@ def marked_string_to_locs(origin_text: str, marked_text: str) -> list[int]:
     original sentence that correspond to the marked words in the second sentence. In the example, the marked
     words are "went" and "store", and their indicies in the original sentence are 3 and 15, so the list
     [3, 15] is returned.
-    
+
     The transformer that generates the marked text is trained to reproduce the original sentence, but there
     is nothing that guarantees that it will do so, and in some cases the transformer will even be inherently
     unable to reproduce the original sentence, such as when the original sentence contains substrings that
     the transformer's tokenizer parses to <unk>.
-    
+
     Therefore this function does not assume that the marked sentence will be identical to the original sentence,
     modulo the trigger marks. Rather the trigger locations are transferred from the marked sentence to the original
     sentence via an alignment between the two sentences.
     """
     locs: list[int] = []
-    
+
     # collapse the space between each "*" and the word it marks so that there are not extra spaces during alignment
     marked_text = marked_text.replace("* ", "*")
-    
+
     # align the output of the trigger identification task with the original sentence
     matcher = SequenceMatcher(a=origin_text, b=marked_text, autojunk=False)
     matches = matcher.get_matching_blocks()
-    
+
     # discard the ending null match since there shouldn't be a "*" after the last word, and, if there is one, we
     # don't want to record it as a valid trigger location
     matches = matches[:-1]
-    
+
     # add a starting null match so that we can recognize a "*" marking the first word, if there happens to be one
     matches.insert(0, Match(0, 0, 0))
-    
+
     # any one-character-wide gaps between matches that contain "*" we record as trigger locations
     for match, next_match in zip(matches[:-1], matches[1:]):
-        if (match.a + match.size            == next_match.a and
-            match.b + match.size + len("*") == next_match.b and
-            "*" == marked_text[match.b + match.size]):
+        if (
+            match.a + match.size == next_match.a
+            and match.b + match.size + len("*") == next_match.b
+            and "*" == marked_text[match.b + match.size]
+        ):
             locs.append(next_match.a)
-    
+
     return locs
 
 

--- a/frame_semantic_transformer/data/data_utils.py
+++ b/frame_semantic_transformer/data/data_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import re
 from typing import Iterator, Sequence, TypeVar
+from difflib import SequenceMatcher, Match
 from torch import Tensor
 
 from transformers import T5TokenizerFast
@@ -36,27 +37,47 @@ def standardize_punct(sent: str) -> str:
     return updated_sent.strip()
 
 
-def marked_string_to_locs(
-    text: str, symbol: str = "*", remove_spaces: bool = True
-) -> tuple[str, list[int]]:
+def marked_string_to_locs(origin_text: str, marked_text: str) -> list[int]:
     """
-    Take a string like "He * went to the * store" and return the indices of the tagged words,
-    in this case "went" and "store", and remove the tags (in this case the *'s)
+    Take a sentence like "He went to the store" and also the output of the trigger identification task, which
+    will be a string like "He * went to the * store". We return the character indicies of the words in the
+    original sentence that correspond to the marked words in the second sentence. In the example, the marked
+    words are "went" and "store", and their indicies in the original sentence are 3 and 15, so the list
+    [3, 15] is returned.
+    
+    The transformer that generates the marked text is trained to reproduce the original sentence, but there
+    is nothing that guarantees that it will do so, and in some cases the transformer will even be inherently
+    unable to reproduce the original sentence, such as when the original sentence contains substrings that
+    the transformer's tokenizer parses to <unk>.
+    
+    Therefore this function does not assume that the marked sentence will be identical to the original sentence,
+    modulo the trigger marks. Rather the trigger locations are transferred from the marked sentence to the original
+    sentence via an alignment between the two sentences.
     """
-    output_str = ""
-    remaining_str = text
     locs: list[int] = []
-    symbol_index = remaining_str.find("*")
-
-    while symbol_index != -1:
-        locs.append(symbol_index + len(output_str))
-        output_str += remaining_str[:symbol_index]
-        remaining_str = remaining_str[symbol_index + len(symbol) :]
-        if remove_spaces:
-            remaining_str = remaining_str.strip()
-        symbol_index = remaining_str.find("*")
-    output_str += remaining_str
-    return output_str, locs
+    
+    # collapse the space between each "*" and the word it marks so that there are not extra spaces during alignment
+    marked_text = marked_text.replace("* ", "*")
+    
+    # align the output of the trigger identification task with the original sentence
+    matcher = SequenceMatcher(a=origin_text, b=marked_text, autojunk=False)
+    matches = matcher.get_matching_blocks()
+    
+    # discard the ending null match since there shouldn't be a "*" after the last word, and, if there is one, we
+    # don't want to record it as a valid trigger location
+    matches = matches[:-1]
+    
+    # add a starting null match so that we can recognize a "*" marking the first word, if there happens to be one
+    matches.insert(0, Match(0, 0, 0))
+    
+    # any one-character-wide gaps between matches that contain "*" we record as trigger locations
+    for match, next_match in zip(matches[:-1], matches[1:]):
+        if (match.a + match.size            == next_match.a and
+            match.b + match.size + len("*") == next_match.b and
+            "*" == marked_text[match.b + match.size]):
+            locs.append(next_match.a)
+    
+    return locs
 
 
 def trim_batch(

--- a/tests/data/test_data_utils.py
+++ b/tests/data/test_data_utils.py
@@ -87,22 +87,31 @@ def test_standardize_punct_with_swedish() -> None:
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    "origin_text,marked_text,trigger_locations",
     [
-        ("Hi * there", ("Hi there", [3])),
-        ("Hi there", ("Hi there", [])),
+        ("Hi there", "Hi * there", [3]),
+        ("Hi there", "Hi there", []),
         (
+            "Does Iran intend to become a Nuclear State?",
             "Does Iran * intend to * become a Nuclear State?",
-            ("Does Iran intend to become a Nuclear State?", [10, 20]),
+            [10, 20],
         ),
         (
+            "Does Iran intend to become a Nuclear State?",
             "Does Iran * intend to *become a Nuclear State?",
-            ("Does Iran intend to become a Nuclear State?", [10, 20]),
+            [10, 20],
+        ),
+        (
+            "The people you refer to (<PERSON>, <PERSON>, <PERSON>) were never involved.",
+            "The people you * refer to (PERSON>, PERSON>, PERSON>, PERSON>, PERSON>, PERSON>) were never * involved.",
+            [15, 66],
         ),
     ],
 )
-def test_marked_string_to_locs(input: str, expected: tuple[str, list[int]]) -> None:
-    assert marked_string_to_locs(input) == expected
+def test_marked_string_to_locs(
+    origin_text: str, marked_text: str, trigger_locations: list[int]
+) -> None:
+    assert marked_string_to_locs(origin_text, marked_text) == trigger_locations
 
 
 def test_trim_batch() -> None:


### PR DESCRIPTION
Thanks for making and sharing this library! This pull request contains a feature that I needed and wrote up, in case you care to merge it into the larger project:

The feature adds sophistication when parsing the trigger-word marks (`*`) in the output string generated by the trigger-identification task. Instead of skipping parsing sentences altogether for which the trigger-identification task doesn't produce exactly the same text as the input sentence, we find an alignment between the original text and the trigger-marked text and transfer as many trigger locations as possible to the original sentence. The alignment technique also correctly transfers all the trigger locations in the common case when the two texts *are* exactly the same.

This update allows you to avoid getting a lot of sentences returned with an empty `DetectFramesResult` if the sentences that you're parsing frequently contain substrings that are tokenized as `<unk>` by the T5 tokenizer.

I ran `black`, `flake8`, and `pytest` locally, but I'm not exactly sure how to run them as GitHub Actions connected to this pull request.